### PR TITLE
Fixed/added remember me functionality for logging in

### DIFF
--- a/src/AuthProvider.php
+++ b/src/AuthProvider.php
@@ -104,7 +104,7 @@ class AuthProvider extends Core implements Interfaces\AuthInterface
     if (!$this->isUserInSession()) {
       $login = $this->router()->urlParamAsString('login');
       $password = $this->router()->urlParamAsString('password');
-      $rememberLogin = $this->router()->urlParamAsBool('rememberLogin');
+      $rememberLogin = $this->router()->urlParamAsBool('session-persist');
 
       $login = trim($login);
 
@@ -123,11 +123,7 @@ class AuthProvider extends Core implements Interfaces\AuthInterface
             $this->signIn($authResult);
 
             if ($rememberLogin) {
-              setcookie(
-                $this->sessionManager()->getSalt() . '-user',
-                $userModel->authCookieSerialize($user[$this->loginAttribute], $user[$this->passwordAttribute]),
-                time() + (3600 * 24 * 30)
-              );
+              $this->sessionManager()->prolongSession();
             }
 
             break;

--- a/src/Interfaces/SessionManagerInterface.php
+++ b/src/Interfaces/SessionManagerInterface.php
@@ -7,6 +7,8 @@ interface SessionManagerInterface
 
   public function getSalt(): string;
   public function start(bool $persist, array $options = []): void;
+
+  public function prolongSession(int $seconds = 2592000): void;
   public function stop(): void;
   public function set(string $path, mixed $value, string $key = '');
   public function get(string $path = '', string $key = ''): mixed;

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -55,7 +55,7 @@ class Loader extends Core
 
     try {
       $this->db()->init();
-      $this->sessionManager()->start(true);
+      $this->sessionManager()->start(false);
 
       $this->config()->init();
       $this->router()->init();

--- a/src/SessionManager.php
+++ b/src/SessionManager.php
@@ -31,7 +31,7 @@ class SessionManager extends Core implements Interfaces\SessionManagerInterface
   }
 
   public function start(bool $persist, array $options = []): void
-  { 
+  {
     if (session_status() == PHP_SESSION_NONE && !headers_sent()) {
       if (empty($this->salt)) throw new \Exception('Hubleto: Cannot start session, salt is empty.');
 
@@ -39,13 +39,28 @@ class SessionManager extends Core implements Interfaces\SessionManagerInterface
       session_name($this->salt);
 
       if ($persist) {
-        $options['cookie_lifetime'] = 86400; // 7 days
-        $options['gc_maxlifetime'] = 86400; // 7 days
+        $options['cookie_lifetime'] = 2592000; // 30 days (1 month)
+        $options['gc_maxlifetime'] = 2592000; // 30 days (1 month)
       }
 
       session_start($options);
 
       define('_SESSION_ID', session_id());
+    }
+  }
+
+  public function prolongSession(int $seconds = 2592000): void
+  {
+    if (session_status() == PHP_SESSION_ACTIVE) {
+      setcookie(
+        session_name(),
+        session_id(),
+        time() + $seconds,
+        ini_get('session.cookie_path'),
+        ini_get('session.cookie_domain'),
+        ini_get('session.cookie_secure'),
+        ini_get('session.cookie_httponly')
+      );
     }
   }
 


### PR DESCRIPTION
This pull request updates how user session persistence is managed, standardizing session durations and improving session extension logic. The most notable changes include replacing custom cookie logic with a dedicated method for prolonging sessions, adjusting session lifetime to 30 days, and updating initialization behavior to not persist sessions by default.

**Session Persistence Improvements:**

* Introduced a new `prolongSession` method in `SessionManager` and its interface to extend the session cookie duration in a standardized way, replacing previous manual cookie handling. (`src/SessionManager.php`, `src/Interfaces/SessionManagerInterface.php`) [[1]](diffhunk://#diff-8c351aa956ea03394b47a8a5d217e86224fea5fc21885112746c27ffae7fd81cR52-R66) [[2]](diffhunk://#diff-0c234573caa22a8f959f849ee92117f7cc8dff49de5e984e2dfad64b47491eebR10-R11)
* Updated the authentication flow in `AuthProvider` to use `prolongSession` when "remember me" is enabled, instead of directly setting a user cookie. (`src/AuthProvider.php`)

**Session Duration Standardization:**

* Changed session persistence duration from 7 days to 30 days when the session is set to persist, ensuring consistency across the application. (`src/SessionManager.php`)

**Initialization Behavior:**

* Modified the application loader to start sessions as non-persistent by default, deferring persistence to explicit user actions. (`src/Loader.php`)

**Parameter Naming Consistency:**

* Updated the parameter name for session persistence in the authentication flow from `rememberLogin` to `session-persist` for clarity and consistency. (`src/AuthProvider.php`)