### PR TITLE
Normalize blank email values to null before save

### DIFF
--- a/src/Db/Column/Email.php
+++ b/src/Db/Column/Email.php
@@ -17,6 +17,7 @@ class Email extends Varchar
   public function normalize(mixed $value): mixed
   {
     $value = trim($value);
+    if ($value === '') return null;
     $value = strtolower($value);
     return parent::normalize($value);
   }


### PR DESCRIPTION
Some records were carrying "" for optional email fields. That caused validation issues when saving records. Now blank email values normalize to null instead of an empty string.