### PR TITLE
handle guard messages on delete and skip removed sub-rows on save

### DIFF
--- a/src/Controllers/Api/Record/Delete.php
+++ b/src/Controllers/Api/Record/Delete.php
@@ -36,6 +36,8 @@ class Delete extends \Hubleto\Framework\Controllers\ApiController {
         $this->model->onBeforeDelete((int) $id);
         $rowsAffected = $this->model->record->recordDelete($id);
         $this->model->onAfterDelete((int) $id);
+      } catch (\Hubleto\Framework\Exceptions\RecordSaveException $e) {
+        throw $e;
       } catch (\Throwable $e) {
         $error = $e->getMessage();
         $errorHtml = $this->renderer()->renderExceptionHtml($e, [$this->model]);

--- a/src/EloquentRecordManager.php
+++ b/src/EloquentRecordManager.php
@@ -847,7 +847,9 @@ class EloquentRecordManager extends \Illuminate\Database\Eloquent\Model implemen
       }
 
       if ((bool) ($record['_toBeDeleted_'] ?? false)) {
-        $this->recordDelete((int) $savedRecord['id']);
+        if ((int) ($savedRecord['id'] ?? 0) > 0) {
+          $this->recordDelete((int) $savedRecord['id']);
+        }
         return [];
       } else if ($isCreate) {
         $savedRecord = $this->recordCreate($savedRecord);
@@ -958,13 +960,13 @@ class EloquentRecordManager extends \Illuminate\Database\Eloquent\Model implemen
         switch ($relType) {
           case Model::HAS_MANY:
             foreach ($record[$relName] as $subKey => $subRecord) {
-              if (is_array($subRecord)) {
+              if (is_array($subRecord) && empty($subRecord['_toBeDeleted_'])) {
                 $subRecord = $relModel->record->recordValidate($subRecord, $validateRelations, $tmpRelation);
               }
             }
           break;
           case Model::HAS_ONE:
-            if (is_array($record[$relName])) {
+            if (is_array($record[$relName]) && empty($record[$relName]['_toBeDeleted_'])) {
               $subRecord = $relModel->record->recordValidate($record[$relName], $validateRelations, $tmpRelation);
             }
           break;


### PR DESCRIPTION
Messages when a delete is blocked (Delete.php):
  A model can stop a delete and give a reason. Before, instead of showing that friendly reason, technical error page. Now it shows the reason as a normal, readable message — the same way blocked saves already work.

Removing items before saving (EloquentRecordManager.php):
  - If you added a new child row and then removed it before saving, the app still tried to delete a row that was never saved. Now it just skips it (there's nothing to delete).
  - If you marked a child row for removal, the app still checked that row's required fields, so an unfinished row you were deleting could block the whole save. Now rows you're removing are no longer checked, since they're about to be gone anyway.